### PR TITLE
Correcting the forrtl: error (200)

### DIFF
--- a/anpr/train.py
+++ b/anpr/train.py
@@ -31,6 +31,8 @@ import multiprocessing
 import os
 import time
 
+os.environ['FOR_DISABLE_CONSOLE_CTRL_HANDLER'] = '1'
+
 import cv2
 import numpy
 import tensorflow as tf


### PR DESCRIPTION
It is correcting the forrtl: error (200)

The output of the error is: 

```
forrtl: error (200): program aborting due to control-C event
Image              PC                Routine            Line        Source
libifcoremd.dll    00007FFB8DEB3B58  Unknown               Unknown  Unknown
KERNELBASE.dll     00007FFBD4F93A53  Unknown               Unknown  Unknown
KERNEL32.DLL       00007FFBD6A181F4  Unknown               Unknown  Unknown
ntdll.dll          00007FFBD8EAA251  Unknown               Unknown  Unknown
```